### PR TITLE
feat: set current context

### DIFF
--- a/packages/extension/src/manager/contexts-manager.spec.ts
+++ b/packages/extension/src/manager/contexts-manager.spec.ts
@@ -16,9 +16,18 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { expect, test, vi } from 'vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
 import { ContextsManager } from '/@/manager/contexts-manager';
 import { KubeConfig } from '@kubernetes/client-node';
+import { kubernetes, type Uri, window } from '@podman-desktop/api';
+import { vol } from 'memfs';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vol.reset();
+});
+
+vi.mock(import('node:fs/promises'));
 
 test('default KubeConfig should be empty', () => {
   const contextsManager = new ContextsManager();
@@ -67,4 +76,71 @@ test('update triggers onContextsChange', async () => {
   await contextsManager.update(kubeConfig);
   expect(onContextsChangeCallback).toHaveBeenCalledOnce();
   expect(onContextsChangeCallback).toHaveBeenCalledWith(undefined);
+});
+
+test('setCurrentContext should show error notification if it fails', async () => {
+  const contextsManager = new ContextsManager();
+  const kubeConfig = new KubeConfig();
+  kubeConfig.loadFromString(`
+    clusters:
+      - name: cluster1
+        cluster:
+          server: https://cluster1.example.com
+  `);
+  vi.mocked(kubernetes.getKubeconfig).mockImplementation(() => {
+    throw new Error('error getting kubeconfig path');
+  });
+  await contextsManager.setCurrentContext('context2');
+  expect(window.showNotification).toHaveBeenCalledWith({
+    title: 'Error setting current context',
+    body: 'Setting current context to "context2" failed: Error: error getting kubeconfig path',
+    type: 'error',
+    highlight: true,
+  });
+});
+
+test('setCurrentContext rewrites file with new current context', async () => {
+  const kubeConfigPath = '/path/to/kube/config';
+  vol.fromJSON({
+    [kubeConfigPath]: '{}',
+  });
+  vi.mocked(kubernetes.getKubeconfig).mockReturnValue({
+    path: kubeConfigPath,
+  } as Uri);
+  const contextsManager = new ContextsManager();
+  const kubeConfig = new KubeConfig();
+  const kubeconfigFileContent = `{
+      clusters: [
+        {
+          name: 'cluster1',
+          cluster: {
+            server: 'https://cluster1.example.com',
+          },
+        },
+      ],
+      users: [
+        {
+          name: 'user1',
+        },
+      ],
+      contexts: [
+        {
+          name: 'context1',
+          context: {
+            cluster: 'cluster1',
+            user: 'user1',
+          },
+        },
+      ],
+    }`;
+  kubeConfig.loadFromString(kubeconfigFileContent);
+  await contextsManager.update(kubeConfig);
+
+  await contextsManager.setCurrentContext('context1');
+
+  const fsScreenshot = vol.toJSON();
+  const kubeconfigFile = fsScreenshot['/path/to/kube/config'];
+  const kubeconfigFileNew = new KubeConfig();
+  kubeconfigFileNew.loadFromString(kubeconfigFile ?? '');
+  expect(kubeconfigFileNew.getCurrentContext()).toEqual('context1');
 });

--- a/packages/webview/src/component/ContextCard.spec.ts
+++ b/packages/webview/src/component/ContextCard.spec.ts
@@ -18,9 +18,16 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { expect, test } from 'vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
 import { render } from '@testing-library/svelte';
 import ContextCard from '/@/component/ContextCard.svelte';
+import SetCurrentContextAction from '/@/component/actions/SetCurrentContextAction.svelte';
+
+vi.mock(import('/@/component/actions/SetCurrentContextAction.svelte'));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
 
 test('ContextCard should render with current context', () => {
   const { queryByText } = render(ContextCard, {
@@ -45,6 +52,7 @@ test('ContextCard should render with current context', () => {
   expect(queryByText('Test User')).toBeInTheDocument();
   expect(queryByText('Test Cluster')).toBeInTheDocument();
   expect(queryByText('https://test.cluster')).toBeInTheDocument();
+  expect(SetCurrentContextAction).not.toHaveBeenCalled();
 });
 
 test('ContextCard should render with no current context', () => {
@@ -70,4 +78,5 @@ test('ContextCard should render with no current context', () => {
   expect(queryByText('Test User')).toBeInTheDocument();
   expect(queryByText('Test Cluster')).toBeInTheDocument();
   expect(queryByText('https://test.cluster')).toBeInTheDocument();
+  expect(SetCurrentContextAction).toHaveBeenCalledWith(expect.anything(), { name: 'Test Context' });
 });

--- a/packages/webview/src/component/ContextCard.svelte
+++ b/packages/webview/src/component/ContextCard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import type { Cluster, User } from '@kubernetes/client-node';
 import ContextCardLine from '/@/component/ContextCardLine.svelte';
+import SetCurrentContextAction from '/@/component/actions/SetCurrentContextAction.svelte';
 
 interface Props {
   cluster: Cluster;
@@ -26,6 +27,9 @@ const { cluster, user, name, namespace, currentContext, icon }: Props = $props()
           <span class="font-semibold text-(--pd-content-card-header-text)" aria-label="Context Name">{name}</span>
         </div>
       </div>
+      {#if !currentContext}
+        <SetCurrentContextAction name={name} />
+      {/if}
     </div>
   </div>
   <div class="grow flex-column divide-gray-900 text-(--pd-content-card-text)">

--- a/packages/webview/src/component/actions/SetCurrentContextAction.svelte
+++ b/packages/webview/src/component/actions/SetCurrentContextAction.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+import { faRightToBracket } from '@fortawesome/free-solid-svg-icons';
+import IconButton from '/@/component/button/IconButton.svelte';
+import { Remote } from '/@/remote/remote';
+import { getContext } from 'svelte';
+import { API_CONTEXTS } from '@kubernetes-contexts/channels';
+
+interface Props {
+  name: string;
+}
+const { name }: Props = $props();
+
+const remote = getContext<Remote>(Remote);
+const contextsApi = remote.getProxy(API_CONTEXTS);
+
+async function setCurrentContext(name: string): Promise<void> {
+  await contextsApi.setCurrentContext(name);
+}
+</script>
+
+<IconButton
+  title="Set as Current Context"
+  icon={faRightToBracket}
+  onClick={(): Promise<void> => setCurrentContext(name)} />

--- a/packages/webview/src/component/button/IconButton.spec.ts
+++ b/packages/webview/src/component/button/IconButton.spec.ts
@@ -1,0 +1,53 @@
+/**********************************************************************
+ * Copyright (C) 2023-2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { faRocket } from '@fortawesome/free-solid-svg-icons';
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import IconButton from './IconButton.svelte';
+
+test('expect button to not have inline-flex when hidden is true', async () => {
+  const title = 'title';
+
+  render(IconButton, {
+    title,
+    icon: faRocket,
+    hidden: true,
+  });
+
+  const buttonSpan = screen.getByTitle(title);
+  expect(buttonSpan).toHaveClass('hidden');
+  expect(buttonSpan).not.toHaveClass('inline-flex');
+});
+
+test('expect button to have inline-flex when hidden is false', async () => {
+  const title = 'title';
+
+  render(IconButton, {
+    title,
+    icon: faRocket,
+    hidden: false,
+  });
+
+  const buttonSpan = screen.getByTitle(title);
+  expect(buttonSpan).not.toHaveClass('hidden');
+  expect(buttonSpan).toHaveClass('inline-flex');
+});

--- a/packages/webview/src/component/button/IconButton.svelte
+++ b/packages/webview/src/component/button/IconButton.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+import Fa from 'svelte-fa';
+import { isFontAwesomeIcon } from '@podman-desktop/ui-svelte';
+import { onMount } from 'svelte';
+import type { IconDefinition } from '@fortawesome/free-regular-svg-icons';
+
+interface Props {
+  title: string;
+  icon: IconDefinition | string;
+  fontAwesomeIcon?: IconDefinition;
+  hidden?: boolean;
+  enabled?: boolean;
+  onClick?: () => void;
+  detailed?: boolean;
+  inProgress?: boolean;
+  iconOffset?: string;
+}
+
+let {
+  title,
+  icon,
+  fontAwesomeIcon,
+  hidden = false,
+  enabled = true,
+  onClick = (): void => {},
+  detailed = false,
+  inProgress = false,
+  iconOffset = '',
+}: Props = $props();
+
+const buttonDetailedClass =
+  'text-(--pd-action-button-details-text) bg-(--pd-action-button-details-bg) hover:text-(--pd-action-button-details-hover-text) font-medium rounded-lg text-sm items-center px-3 py-2 text-center';
+const buttonDetailedDisabledClass =
+  'text-(--pd-action-button-details-disabled-text) bg-(--pd-action-button-details-disabled-bg) font-medium rounded-lg text-sm  items-center px-3 py-2 text-center';
+const buttonClass =
+  'text-(--pd-action-button-text) hover:bg-(--pd-action-button-hover-bg) hover:text-(--pd-action-button-hover-text) font-medium rounded-full items-center px-2 py-2 text-center';
+const buttonDisabledClass =
+  'text-(--pd-action-button-disabled-text) font-medium rounded-full items-center px-2 py-2 text-center';
+
+const styleClass = $derived(
+  detailed
+    ? enabled && !inProgress
+      ? buttonDetailedClass
+      : buttonDetailedDisabledClass
+    : enabled && !inProgress
+      ? buttonClass
+      : buttonDisabledClass,
+);
+
+let positionLeftClass = $state('left-1');
+if (detailed) positionLeftClass = 'left-2';
+
+let positionTopClass = $state('top-1');
+if (detailed) positionTopClass = '[0.2rem]';
+
+onMount(() => {
+  if (isFontAwesomeIcon(icon)) {
+    fontAwesomeIcon = icon;
+  }
+});
+
+function handleClick(): void {
+  if (enabled && !inProgress) {
+    onClick();
+  }
+}
+</script>
+
+<button
+  title={title}
+  aria-label={title}
+  onclick={handleClick}
+  class="{styleClass} relative"
+  class:disabled={inProgress}
+  class:hidden={hidden}
+  class:inline-flex={!hidden}
+  disabled={!enabled}>
+  {#if fontAwesomeIcon}
+    <Fa class="h-4 w-4 {iconOffset}" icon={fontAwesomeIcon} />
+  {/if}
+
+  <div
+    aria-label="spinner"
+    class="w-6 h-6 rounded-full animate-spin border border-solid border-(--pd-action-button-spinner) border-t-transparent absolute {positionTopClass} {positionLeftClass}"
+    class:hidden={!inProgress}>
+  </div>
+</button>


### PR DESCRIPTION
Display the button to set a context as current.

When an error occurs, a notification is sent (you can run `chmod u-w ~/.kube/config` to test error scenario - `chmod u+w ~/.kube/config` to revert)

Fixes #17 