### PR TITLE
feat: listen contexts healths from Dashboard API 

### DIFF
--- a/packages/channels/src/channels.ts
+++ b/packages/channels/src/channels.ts
@@ -20,6 +20,7 @@ import type { ContextsApi } from './interface/contexts-api';
 import { createRpcChannel } from '@kubernetes-contexts/rpc';
 import type { AvailableContextsInfo } from '/@/model/available-contexts-info';
 import type { SubscribeApi } from '/@/interface';
+import type { ContextsHealthsInfo } from '@podman-desktop/kubernetes-dashboard-extension-api';
 
 // RPC channels (used by the webview to send requests to the extension)
 export const API_CONTEXTS = createRpcChannel<ContextsApi>('ContextsApi');
@@ -27,3 +28,4 @@ export const API_SUBSCRIBE = createRpcChannel<SubscribeApi>('SubscribeApi');
 
 // Broadcast events (sent by extension and received by the webview)
 export const AVAILABLE_CONTEXTS = createRpcChannel<AvailableContextsInfo>('AvailableContexts');
+export const CONTEXT_HEALTHS = createRpcChannel<ContextsHealthsInfo>('ContextsHealths');

--- a/packages/extension/src/dispatcher/_dispatcher-module.ts
+++ b/packages/extension/src/dispatcher/_dispatcher-module.ts
@@ -19,10 +19,14 @@
 import { ContainerModule } from 'inversify';
 import { DispatcherObject } from './util/dispatcher-object';
 import { AvailableContextsDispatcher } from './available-contexts-dispatcher';
+import { ContextsHealthsDispatcher } from '/@/dispatcher/contexts-healths-dispatcher';
 
 const dispatchersModule = new ContainerModule(options => {
   options.bind<AvailableContextsDispatcher>(AvailableContextsDispatcher).toSelf().inSingletonScope();
   options.bind(DispatcherObject).toService(AvailableContextsDispatcher);
+
+  options.bind<ContextsHealthsDispatcher>(ContextsHealthsDispatcher).toSelf().inSingletonScope();
+  options.bind(DispatcherObject).toService(ContextsHealthsDispatcher);
 });
 
 export { dispatchersModule };

--- a/packages/extension/src/dispatcher/contexts-healths-dispatcher.ts
+++ b/packages/extension/src/dispatcher/contexts-healths-dispatcher.ts
@@ -1,0 +1,42 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { inject, injectable } from 'inversify';
+import type { DispatcherObject } from './util/dispatcher-object';
+import { AbsDispatcherObjectImpl } from './util/dispatcher-object';
+import { CONTEXT_HEALTHS } from '@kubernetes-contexts/channels';
+import { RpcExtension } from '@kubernetes-contexts/rpc';
+import { ContextsHealthsInfo } from '@podman-desktop/kubernetes-dashboard-extension-api';
+import { DashboardStatesManager } from '/@/manager/dashboard-states-manager';
+
+@injectable()
+export class ContextsHealthsDispatcher
+  extends AbsDispatcherObjectImpl<void, ContextsHealthsInfo>
+  implements DispatcherObject<void>
+{
+  constructor(
+    @inject(RpcExtension) rpcExtension: RpcExtension,
+    @inject(DashboardStatesManager) private dashboardStatesManager: DashboardStatesManager,
+  ) {
+    super(rpcExtension, CONTEXT_HEALTHS);
+  }
+
+  getData(): ContextsHealthsInfo {
+    return this.dashboardStatesManager.getContextsHealths();
+  }
+}

--- a/packages/extension/src/manager/dispatcher.ts
+++ b/packages/extension/src/manager/dispatcher.ts
@@ -21,12 +21,16 @@ import { RpcChannel } from '@kubernetes-contexts/rpc';
 import { inject, injectable, multiInject } from 'inversify';
 import { DispatcherObject } from '/@/dispatcher/util/dispatcher-object.js';
 import { ChannelSubscriber } from '/@/manager/channel-subscriber.js';
-import { AVAILABLE_CONTEXTS } from '@kubernetes-contexts/channels';
+import { AVAILABLE_CONTEXTS, CONTEXT_HEALTHS } from '@kubernetes-contexts/channels';
+import { DashboardStatesManager } from '/@/manager/dashboard-states-manager.js';
 
 @injectable()
 export class Dispatcher {
   @inject(ContextsManager)
   private manager: ContextsManager;
+
+  @inject(DashboardStatesManager)
+  private dashboardStatesManager: DashboardStatesManager;
 
   #dispatchers: Map<string, DispatcherObject<unknown>> = new Map();
   #channelSubscriber: ChannelSubscriber;
@@ -44,6 +48,9 @@ export class Dispatcher {
   init(): void {
     this.manager.onContextsChange(async () => {
       await this.dispatch(AVAILABLE_CONTEXTS);
+    });
+    this.dashboardStatesManager.onContextsHealthChange(async () => {
+      await this.dispatch(CONTEXT_HEALTHS);
     });
 
     this.#channelSubscriber.onSubscribe(async channelName => await this.dispatchByChannelName(channelName));


### PR DESCRIPTION
Listen contexts healths from Dashboard API and dispatch the data when it is updated (next step will be to listen to this data from the webview)

Part of #21 
