### PR TITLE
chore: use eslint copyright plugin

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -37,6 +37,12 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 10 # must be at least the number of commits in the PR, for eslint copyright check
+
+      - name: fetch year's commits and at least one commit of last year, for eslint copyright check
+        run: |
+         git fetch --shallow-since=2025-12-30 
 
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
         name: Install pnpm

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -35,6 +35,7 @@ import redundantUndefined from 'eslint-plugin-redundant-undefined';
 import simpleImportSort from 'eslint-plugin-simple-import-sort';
 import vitest from '@vitest/eslint-plugin';
 import betterTailwindcss from 'eslint-plugin-better-tailwindcss';
+import podmanDesktopLinter from '@podman-desktop/eslint-plugin';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -69,6 +70,7 @@ export default [
   sonarjs.configs.recommended,
   ...svelte.configs['flat/recommended'],
   vitest.configs.recommended,
+  podmanDesktopLinter.configs.recommended,
   ...fixupConfigRules(
     compat.extends('plugin:import/recommended', 'plugin:import/typescript', 'plugin:etc/recommended'),
   ),

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "@eslint/compat": "^2.0.2",
     "@eslint/js": "^9.39.2",
+    "@podman-desktop/eslint-plugin": "^0.2.0",
     "@tsconfig/strictest": "^2.0.6",
     "@typescript-eslint/eslint-plugin": "^8.55.0",
     "@typescript-eslint/parser": "^8.55.0",

--- a/packages/channels/src/interface/contexts-api.ts
+++ b/packages/channels/src/interface/contexts-api.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/channels/src/model/import-context-info.ts
+++ b/packages/channels/src/model/import-context-info.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/channels/src/model/index.ts
+++ b/packages/channels/src/model/index.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/extension/src/main.spec.ts
+++ b/packages/extension/src/main.spec.ts
@@ -1,3 +1,21 @@
+/*******************************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
 import type { ExtensionContext } from '@podman-desktop/api';
 import { beforeEach, expect, test, vi } from 'vitest';
 import { activate, deactivate } from '/@/main';

--- a/packages/extension/src/manager/contexts-manager.spec.ts
+++ b/packages/extension/src/manager/contexts-manager.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 - 2025 Red Hat, Inc.
+ * Copyright (C) 2024-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/extension/src/manager/contexts-manager.ts
+++ b/packages/extension/src/manager/contexts-manager.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 - 2025 Red Hat, Inc.
+ * Copyright (C) 2024-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/extension/src/manager/dispatcher.ts
+++ b/packages/extension/src/manager/dispatcher.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/extension/src/types/emitter.ts
+++ b/packages/extension/src/types/emitter.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2024 Red Hat, Inc.
+ * Copyright (C) 2023-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/rpc/src/index.ts
+++ b/packages/rpc/src/index.ts
@@ -1,3 +1,21 @@
+/*******************************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
 import { createRpcChannel, RpcChannel, RpcExtension, RpcBrowser } from './rpc';
 
 export { createRpcChannel, RpcChannel, RpcExtension, RpcBrowser };

--- a/packages/webview/src/component/ContextCard.spec.ts
+++ b/packages/webview/src/component/ContextCard.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/webview/src/component/ContextResources.spec.ts
+++ b/packages/webview/src/component/ContextResources.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/webview/src/component/ContextStatus.spec.ts
+++ b/packages/webview/src/component/ContextStatus.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/webview/src/component/ContextsList.spec.ts
+++ b/packages/webview/src/component/ContextsList.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/webview/src/component/ImportContextCard.spec.ts
+++ b/packages/webview/src/component/ImportContextCard.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.

--- a/packages/webview/src/component/KubeIcon.ts
+++ b/packages/webview/src/component/KubeIcon.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022-2023 Red Hat, Inc.
+ * Copyright (C) 2022-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/webview/src/component/dialog/Dialog.spec.ts
+++ b/packages/webview/src/component/dialog/Dialog.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/webview/src/component/dialog/DialogSpec.spec.ts
+++ b/packages/webview/src/component/dialog/DialogSpec.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
       '@eslint/js':
         specifier: ^9.39.2
         version: 9.39.2
+      '@podman-desktop/eslint-plugin':
+        specifier: ^0.2.0
+        version: 0.2.0(eslint@9.39.2(jiti@2.6.1))
       '@tsconfig/strictest':
         specifier: ^2.0.6
         version: 2.0.8
@@ -903,6 +906,12 @@ packages:
 
   '@podman-desktop/api@1.25.1':
     resolution: {integrity: sha512-OTsf2q0g5GavfalYFpOtyn8QVVkLKKJOH1zMabqcIK7yTpu093FRCQY/hBdUYx25UyEXhtX4v7QAP0+lc9B+jw==}
+
+  '@podman-desktop/eslint-plugin@0.2.0':
+    resolution: {integrity: sha512-Svp+48+1ddO4j3w0FMCwiU0ooorGMZHaqgEZkqOCKvdpvoLfJ44yXoSHuJYSnxGQNZsQjxNN7MCbd0hGNSkGPw==}
+    engines: {node: '>=24 <25'}
+    peerDependencies:
+      eslint: '>=9.0.0'
 
   '@podman-desktop/kubernetes-dashboard-extension-api@0.5.0':
     resolution: {integrity: sha512-XlyvBGo2iDGVFEVEzWSmHozoV4yopxRy4aLeGaGX5/V5OvYy8HLduaG/Rhnjb09m/fhdkKKWmCSct5Pi1HkfmQ==}
@@ -4649,6 +4658,10 @@ snapshots:
   '@pkgr/core@0.2.9': {}
 
   '@podman-desktop/api@1.25.1': {}
+
+  '@podman-desktop/eslint-plugin@0.2.0(eslint@9.39.2(jiti@2.6.1))':
+    dependencies:
+      eslint: 9.39.2(jiti@2.6.1)
 
   '@podman-desktop/kubernetes-dashboard-extension-api@0.5.0': {}
 


### PR DESCRIPTION
- use plugin https://github.com/podman-desktop/eslint-plugin
- fix missing / incorrect copyright headers
- from ci, fetch commits of the year and at least one commit of last year