### PR TITLE
fix(lint): suppress false-positive vitest/valid-expect on expect.any()

### DIFF
--- a/packages/webview/src/component/ContextsList.spec.ts
+++ b/packages/webview/src/component/ContextsList.spec.ts
@@ -121,6 +121,7 @@ test('ContextCardLine should render cards when available contexts', () => {
     namespace: 'test-namespace-1',
     currentContext: true,
     icon: kubernetesIconBase64,
+    // eslint-disable-next-line vitest/valid-expect
     onEdit: expect.any(Function),
   });
   expect(ContextCard).toHaveBeenCalledWith(expect.anything(), {
@@ -136,6 +137,7 @@ test('ContextCardLine should render cards when available contexts', () => {
     namespace: undefined,
     currentContext: false,
     icon: kubernetesIconBase64,
+    // eslint-disable-next-line vitest/valid-expect
     onEdit: expect.any(Function),
   });
   expect(uiSvelte.EmptyScreen).not.toHaveBeenCalled();


### PR DESCRIPTION
needed by #570 

The vitest/valid-expect rule is incorrectly flagging expect.any(Function) as an unknown modifier — it's treating any as a modifier on
  expect rather than recognizing it as a static asymmetric matcher method. The fix is to add eslint-disable comments on those two lines.
