### PR TITLE
fix: resolve GHSA-2v37-7h3g-55p8 in nanoid

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,7 @@ overrides:
   undici@<6.27.0: '>=6.27.0 <7'
   shell-quote@<=1.8.4: '>=1.9.0'
   rollup@>=4.0.0 <4.59.0: '>=4.59.0'
+  nanoid@<3.3.18: '>=3.3.18'
 
 importers:
 
@@ -3130,11 +3131,6 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
-
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
 
   nanoid@3.3.18:
     resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
@@ -7132,8 +7128,6 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.12: {}
-
   nanoid@3.3.18: {}
 
   nanospinner@1.2.2:
@@ -7331,7 +7325,7 @@ snapshots:
 
   postcss@8.5.15:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,6 +20,7 @@ overrides:
   undici@<6.27.0: '>=6.27.0 <7'
   shell-quote@<=1.8.4: '>=1.9.0'
   rollup@>=4.0.0 <4.59.0: '>=4.59.0'
+  nanoid@<3.3.18: '>=3.3.18'
 nodeLinker: hoisted
 allowBuilds:
   esbuild: true


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability GHSA-2v37-7h3g-55p8 in `nanoid`.

**Advisory**: nanoid: custom generators can loop indefinitely when size is zero
**Vulnerable versions**: <3.3.18
**Patched versions**: >=3.3.18
**Advisory URL**: https://github.com/advisories/GHSA-2v37-7h3g-55p8

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes GHSA-2v37-7h3g-55p8: _nanoid: custom generators can loop indefinitely when size is zero_

### How to test this PR?

Run `pnpm audit` and verify GHSA-2v37-7h3g-55p8 is no longer reported