### PR TITLE
fix: resolve GHSA-r292-9mhp-454m in tar

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,7 @@ overrides:
   shell-quote@<=1.8.4: '>=1.9.0'
   rollup@>=4.0.0 <4.59.0: '>=4.59.0'
   nanoid@<3.3.18: '>=3.3.18'
+  tar@<=7.5.20: '>=7.5.21'
 
 importers:
 
@@ -3763,8 +3764,8 @@ packages:
   tar-stream@3.2.0:
     resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
 
-  tar@7.5.19:
-    resolution: {integrity: sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==}
+  tar@7.5.22:
+    resolution: {integrity: sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==}
     engines: {node: '>=18'}
 
   teex@1.0.1:
@@ -7116,7 +7117,7 @@ snapshots:
       nopt: 10.0.1
       proc-log: 7.0.0
       semver: 7.8.5
-      tar: 7.5.19
+      tar: 7.5.22
       tinyglobby: 0.2.17
       undici: 8.6.0
       which: 7.0.0
@@ -7750,7 +7751,7 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
-  tar@7.5.19:
+  tar@7.5.22:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,6 +21,7 @@ overrides:
   shell-quote@<=1.8.4: '>=1.9.0'
   rollup@>=4.0.0 <4.59.0: '>=4.59.0'
   nanoid@<3.3.18: '>=3.3.18'
+  tar@<=7.5.20: '>=7.5.21'
 nodeLinker: hoisted
 allowBuilds:
   esbuild: true


### PR DESCRIPTION
### What does this PR do?

Fix moderate severity vulnerability GHSA-r292-9mhp-454m in `tar`.

**Advisory**: node-tar: Uncontrolled recursion in mapHas/filesFilter allows uncatchable stack-overflow DoS via crafted long-path tar with member selection
**Vulnerable versions**: <=7.5.20
**Patched versions**: >=7.5.21
**Advisory URL**: https://github.com/advisories/GHSA-r292-9mhp-454m

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes GHSA-r292-9mhp-454m: _node-tar: Uncontrolled recursion in mapHas/filesFilter allows uncatchable stack-overflow DoS via crafted long-path tar with member selection_

### How to test this PR?

Run `pnpm audit` and verify GHSA-r292-9mhp-454m is no longer reported