### PR TITLE
fix: resolve GHSA-7p8r-x3mc-p8w7 in fast-uri

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,7 @@ overrides:
   rollup@>=4.0.0 <4.59.0: '>=4.59.0'
   nanoid@<3.3.18: '>=3.3.18'
   tar@<=7.5.20: '>=7.5.21'
+  fast-uri@>=3.0.0 <3.1.5: '>=3.1.5 <4'
 
 importers:
 
@@ -2373,8 +2374,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -5490,7 +5491,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
     optional: true
@@ -6394,7 +6395,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.4:
+  fast-uri@3.1.5:
     optional: true
 
   fastq@1.19.1:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,6 +23,7 @@ overrides:
   rollup@>=4.0.0 <4.59.0: '>=4.59.0'
   nanoid@<3.3.18: '>=3.3.18'
   tar@<=7.5.20: '>=7.5.21'
+  fast-uri@>=3.0.0 <3.1.5: '>=3.1.5 <4'
 nodeLinker: hoisted
 allowBuilds:
   esbuild: true


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability GHSA-7p8r-x3mc-p8w7 in `fast-uri`.

**Advisory**: fast-uri vulnerable to host confusion via backslash authority introducer
**Vulnerable versions**: >=3.0.0 <3.1.5
**Patched versions**: >=3.1.5
**Advisory URL**: https://github.com/advisories/GHSA-7p8r-x3mc-p8w7

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes GHSA-7p8r-x3mc-p8w7: _fast-uri vulnerable to host confusion via backslash authority introducer_

### How to test this PR?

Run `pnpm audit` and verify GHSA-7p8r-x3mc-p8w7 is no longer reported